### PR TITLE
Log and close app if leaderboard is missing

### DIFF
--- a/commands/leaderboard.go
+++ b/commands/leaderboard.go
@@ -1,6 +1,7 @@
 package points
 
 import (
+	"fmt"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -14,6 +15,10 @@ type Leaderboard struct {
 }
 
 func (lb *Leaderboard) Load(filename string) {
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "A leaderboard '%v' does not exist in this directory!\n", filename)
+	}
+
 	lb.filename = filename
 	in, _ := ioutil.ReadFile(filename)
 	json.Unmarshal(in, &lb)


### PR DESCRIPTION
Prevents app from starting if the leaderboard doesn't exist.